### PR TITLE
 #17082 : Grid row delete confirmation modal - Catalog > Suppliers

### DIFF
--- a/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/SupplierGridDefinitionFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
-use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\LinkGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
@@ -58,6 +57,7 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
     public const GRID_ID = 'supplier';
 
     use BulkDeleteActionTrait;
+    use DeleteActionTrait;
 
     /**
      * {@inheritdoc}
@@ -145,20 +145,12 @@ final class SupplierGridDefinitionFactory extends AbstractGridDefinitionFactory
                                 'route_param_field' => 'id_supplier',
                             ])
                         )
-                        ->add((new SubmitRowAction('delete'))
-                            ->setName($this->trans('Delete', [], 'Admin.Actions'))
-                            ->setIcon('delete')
-                            ->setOptions([
-                                'method' => 'DELETE',
-                                'route' => 'admin_suppliers_delete',
-                                'route_param_name' => 'supplierId',
-                                'route_param_field' => 'id_supplier',
-                                'confirm_message' => $this->trans(
-                                    'Delete selected item?',
-                                    [],
-                                    'Admin.Notifications.Warning'
-                                ),
-                            ])
+                        ->add(
+                            $this->buildDeleteAction(
+                                'admin_suppliers_delete',
+                                'supplierId',
+                                'id_supplier'
+                            )
                         ),
                 ])
             )


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Add a confirmation modal when deleting a row from a grid.<br> Catalog > Suppliers
| Type?         | improvement
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially Fixes #17082
| How to test?  | Go to Catalog > Suppliers in the BO, Try to delete a row, you will have a bootstrap modal to confirm deletion