### PR TITLE
Export modules translations in Legacy and XLF formats

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.js
+++ b/admin-dev/themes/new-theme/js/pages/translation-settings/FormFieldToggle.js
@@ -65,9 +65,11 @@ const emailContentBody = 'body';
 export default class FormFieldToggle {
   constructor() {
     $('.js-translation-type').on('change', this.toggleFields.bind(this));
+    $('.js-export-type').on('change', this.toggleExportFields.bind(this));
     $('.js-email-content-type').on('change', this.toggleEmailFields.bind(this));
 
     this.toggleFields();
+    this.toggleExportFields();
   }
 
   /**
@@ -105,6 +107,30 @@ export default class FormFieldToggle {
     }
 
     this.toggleEmailFields();
+  }
+
+  /**
+   * Toggle dependant exports fields, based on selected export type
+   */
+  toggleExportFields() {
+    const selectedOption = $('.js-export-type').val();
+    const $modulesFormGroup = $('.js-module-export-form-group');
+    const $themesFormGroup = $('.js-theme-export-form-group');
+
+    switch (selectedOption) {
+      case themes:
+        this.hide($modulesFormGroup);
+        this.show($themesFormGroup);
+        break;
+
+      case modules:
+        this.hide($themesFormGroup);
+        this.show($modulesFormGroup);
+        break;
+
+      default:
+        break;
+    }
   }
 
   /**

--- a/src/Core/Form/ChoiceProvider/TranslationExportTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/TranslationExportTypeChoiceProvider.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
+
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Class TranslationExportTypeByNameChoiceProvider provides translation export type choices.
+ */
+final class TranslationExportTypeChoiceProvider implements FormChoiceProviderInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChoices()
+    {
+        return [
+            $this->translator->trans('Front office Translations', [], 'Admin.International.Feature') => 'themes',
+            $this->translator->trans('Installed modules translations', [], 'Admin.International.Feature') => 'modules',
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -68,7 +68,7 @@ class TranslationController extends ApiController
      *
      * @return JsonResponse
      */
-    public function listDomainTranslationAction(Request $request)
+    public function listDomainTranslationAction(Request $request): JsonResponse
     {
         try {
             $queryParamsCollection = $this->queryParams->fromRequest($request);

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportLanguageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Translations/ExportLanguageType.php
@@ -32,28 +32,42 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
- * Class ExportThemeLanguageType is responsible for building export language form
+ * Class ExportLanguageType is responsible for building export language form
  * in 'Improve > International > Translations' page.
  */
-class ExportThemeLanguageType extends TranslatorAwareType
+class ExportLanguageType extends TranslatorAwareType
 {
     /**
      * @var array
      */
     private $themeChoices;
+    /**
+     * @var array
+     */
+    private $moduleChoices;
+    /**
+     * @var array
+     */
+    private $translationExportTypeChoices;
 
     /**
      * @param TranslatorInterface $translator
      * @param array $locales
+     * @param array $translationExportTypeChoices
      * @param array $themeChoices
+     * @param array $moduleChoices
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        array $themeChoices
+        array $translationExportTypeChoices,
+        array $themeChoices,
+        array $moduleChoices
     ) {
         parent::__construct($translator, $locales);
+        $this->translationExportTypeChoices = $translationExportTypeChoices;
         $this->themeChoices = $themeChoices;
+        $this->moduleChoices = $moduleChoices;
     }
 
     /**
@@ -66,8 +80,17 @@ class ExportThemeLanguageType extends TranslatorAwareType
                 'choices' => $this->getLocaleChoices(),
                 'choice_translation_domain' => false,
             ])
+            ->add('translation_export_type', ChoiceType::class, [
+                'choices' => $this->translationExportTypeChoices,
+                'choice_translation_domain' => false,
+            ])
             ->add('theme_name', ChoiceType::class, [
                 'choices' => $this->themeChoices,
+                'choice_translation_domain' => false,
+            ])
+            ->add('module_name', ChoiceType::class, [
+                'placeholder' => '---',
+                'choices' => $this->moduleChoices,
                 'choice_translation_domain' => false,
             ]);
     }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/translations.yml
@@ -6,11 +6,11 @@ admin_international_translation_overview:
         _legacy_controller: AdminTranslations
         _legacy_link: AdminTranslationSf
 
-admin_international_translations_export_theme:
+admin_international_translations_export:
     path: /export
-    methods:  [POST]
+    methods: [ POST ]
     defaults:
-        _controller: PrestaShopBundle:Admin/Translations:exportThemeLanguage
+        _controller: PrestaShopBundle:Admin/Translations:export
         _legacy_controller: AdminTranslations
         _legacy_link: AdminTranslations:submitExport
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_handler.yml
@@ -417,7 +417,7 @@ services:
         arguments:
             - '@form.factory'
             - '@prestashop.core.hook.dispatcher'
-            - 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ExportThemeLanguageType'
+            - 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ExportLanguageType'
             - 'TranslationSettingsPageExportLanguage'
 
     prestashop.admin.translations_settings.copy_language.form_handler:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -566,11 +566,13 @@ services:
             - { name: form.type }
 
     form.type.translations.export_language:
-        class: 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ExportThemeLanguageType'
+        class: 'PrestaShopBundle\Form\Admin\Improve\International\Translations\ExportLanguageType'
         parent: 'form.type.translatable.aware'
         public: true
         arguments:
+            - '@=service("prestashop.core.form.choice_provider.translation_export_type").getChoices()'
             - '@=service("prestashop.core.form.choice_provider.theme_by_name").getChoices()'
+            - '@=service("prestashop.core.form.choice_provider.module_by_name").getChoices()'
         tags:
             - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -3,6 +3,7 @@ parameters:
     ps_config_dir:                  "%ps_root_dir%config"
     translations_dir:               "%kernel.root_dir%/Resources/translations"
     themes_translations_cache_dir:  "%kernel.cache_dir%/themes"
+    modules_translations_cache_dir: "%kernel.cache_dir%/modules"
     modules_dir:                    "%kernel.root_dir%/../modules"
     themes_dir:                     "%kernel.root_dir%/../themes"
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -94,6 +94,22 @@ services:
     prestashop.translation.dumper.xliff:
         class: PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper
 
+    prestashop.translation.dumper.php:
+        class: PrestaShop\TranslationToolsBundle\Translation\Dumper\PhpDumper
+
+    prestashop.translation.exporter.module:
+        class: PrestaShopBundle\Translation\Exporter\ModuleExporter
+        arguments:
+            - '@prestashop.translation.extractor.legacy_module'
+            - "@prestashop.translation.provider_factory"
+            - "@prestashop.translation.dumper.xliff"
+            - "@prestashop.translation.dumper.php"
+            - "@prestashop.utils.zip_manager"
+            - "@filesystem"
+            - "%modules_translations_cache_dir%"
+        calls:
+            - [ setExportDir, ["%kernel.cache_dir%/export"]]
+
     prestashop.translation.exporter.theme:
         class: PrestaShopBundle\Translation\Exporter\ThemeExporter
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -91,6 +91,11 @@ services:
     arguments:
       - '@translator'
 
+  prestashop.core.form.choice_provider.translation_export_type:
+    class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\TranslationExportTypeChoiceProvider'
+    arguments:
+      - '@translator'
+
   prestashop.core.form.choice_provider.email_content_type:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\EmailContentTypeChoiceProvider'
     arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
@@ -25,7 +25,7 @@
 
 {% trans_default_domain 'Admin.International.Feature' %}
 
-{{ form_start(exportLanguageForm, {action: path('admin_international_translations_export_theme')}) }}
+{{ form_start(exportLanguageForm, {action: path('admin_international_translations_export')}) }}
 
 <div class="card">
   <h3 class="card-header">
@@ -53,8 +53,17 @@
           {{ form_widget(exportLanguageForm.iso_code) }}
         </div>
       </div>
-
       <div class="form-group row">
+        <label class="form-control-label">
+          {{ 'Type of translation'|trans }}
+        </label>
+        <div class="col-sm">
+          {{ form_errors(exportLanguageForm.translation_export_type) }}
+          {{ form_widget(exportLanguageForm.translation_export_type, {'attr': {'class': 'js-export-type'}}) }}
+        </div>
+      </div>
+
+      <div class="form-group row js-theme-export-form-group d-none">
         <label class="form-control-label">
           {{ 'Select your theme'|trans }}
         </label>
@@ -63,6 +72,16 @@
           {{ form_widget(exportLanguageForm.theme_name) }}
         </div>
       </div>
+      <div class="form-group row js-module-export-form-group d-none">
+        <label class="form-control-label">
+          {{ 'Select your module'|trans }}
+        </label>
+        <div class="col-sm">
+          {{ form_errors(exportLanguageForm.module_name) }}
+          {{ form_widget(exportLanguageForm.module_name, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}) }}
+        </div>
+      </div>
+
       {{ form_rest(exportLanguageForm) }}
     </div>
   </div>

--- a/src/PrestaShopBundle/Translation/Exporter/ModuleExporter.php
+++ b/src/PrestaShopBundle/Translation/Exporter/ModuleExporter.php
@@ -1,0 +1,375 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Translation\Exporter;
+
+use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
+use PrestaShop\TranslationToolsBundle\Translation\Dumper\PhpDumper;
+use PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\Util\Flattenizer;
+use PrestaShopBundle\Exception\NotImplementedException;
+use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractorInterface;
+use PrestaShopBundle\Translation\Provider\Factory\ProviderFactory;
+use PrestaShopBundle\Translation\Provider\Type\ModulesType;
+use PrestaShopBundle\Utils\ZipManager;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+/**
+ * Exports a module's translations
+ */
+class ModuleExporter
+{
+    /**
+     * @var ZipManager the zip manager
+     */
+    private $zipManager;
+
+    /**
+     * @var XliffFileDumper the Xliff dumper
+     */
+    private $dumper;
+
+    /**
+     * @var Filesystem the Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var string the export directory path
+     */
+    public $exportDir;
+    /**
+     * @var ProviderFactory
+     */
+    private $providerFactory;
+    /**
+     * @var string
+     */
+    private $cacheDir;
+    /**
+     * @var PhpDumper
+     */
+    private $phpDumper;
+    /**
+     * @var LegacyModuleExtractorInterface
+     */
+    private $legacyModuleExtractor;
+
+    public function __construct(
+        LegacyModuleExtractorInterface $legacyModuleExtractor,
+        ProviderFactory $providerFactory,
+        XliffFileDumper $dumper,
+        PhpDumper $phpDumper,
+        ZipManager $zipManager,
+        Filesystem $filesystem,
+        string $cacheDir
+    ) {
+        $this->dumper = $dumper;
+        $this->zipManager = $zipManager;
+        $this->filesystem = $filesystem;
+        $this->providerFactory = $providerFactory;
+        $this->cacheDir = $cacheDir;
+        $this->phpDumper = $phpDumper;
+        $this->legacyModuleExtractor = $legacyModuleExtractor;
+    }
+
+    /**
+     * Extracts the module's translations in a particular locale and bundles them in a zip file
+     *
+     * @param string $moduleName Module name
+     * @param string $locale Locale for the exported catalogue
+     * @param string|false $rootDir Path to use as root for the translation metadata
+     *
+     * @return string Full path to the zip file
+     */
+    public function createZipArchive($moduleName, $locale, $rootDir = false)
+    {
+        $archiveParentDirectory = $this->exportCatalogues($moduleName, $locale, $rootDir);
+        $zipFilename = $this->makeZipFilename($moduleName, $locale);
+        $this->zipManager->createArchive($zipFilename, $archiveParentDirectory);
+
+        return $zipFilename;
+    }
+
+    /**
+     * Extracts the module's translations in a particular locale as XLIFF files in a temporary directory
+     *
+     * @param string $moduleName Module name
+     * @param string $locale Locale for the exported catalogue
+     * @param string|false $rootDir Path to use as root for the translation metadata
+     *
+     * @return string The directory where the files have been exported
+     *
+     * @throws NotImplementedException
+     */
+    public function exportCatalogues(string $moduleName, string $locale, $rootDir = false): string
+    {
+        $catalogue = $this->getCatalogue($moduleName, $locale);
+
+        // $storageFilesPath = var/cache/test/ps_banner-tmp
+        $storageFilesPath = $this->getStorageFilesPath($moduleName);
+        // $temporaryFilesPath = cacheDir/moduleName
+        $temporaryFilesPath = $this->getTemporaryFilesPath($moduleName);
+
+        $this->filesystem->remove($temporaryFilesPath);
+
+        // $tmpExtractPath = cacheDir/moduleName/LOCALE
+        $tmpExtractPath = $temporaryFilesPath . DIRECTORY_SEPARATOR . $locale;
+
+        $this->filesystem->mkdir($tmpExtractPath);
+
+        $this->dumper->dump($catalogue, [
+            'path' => $temporaryFilesPath,
+            'default_locale' => $locale,
+            'root_dir' => $rootDir,
+        ]);
+
+        // The files in cacheDir/moduleName/LOCALE are flatten into cacheDir/export/moduleName/LOCALE/
+        // so that the translation files structure is DomainoneDomaintwoFinaleSheet.LOCALE.xlf
+        Flattenizer::flatten(
+            $tmpExtractPath,
+            $storageFilesPath . DIRECTORY_SEPARATOR . $locale,
+            $locale
+        );
+
+        $this->phpDumper->dump($catalogue, [
+            'path' => $storageFilesPath,
+            'default_locale' => $locale,
+            'root_dir' => $rootDir,
+        ]);
+
+        // $archiveDirectory = cacheDir/export/moduleName/LOCALE/
+        $archiveDirectory = $this->getExportDir($moduleName);
+        if (!$this->filesystem->exists($archiveDirectory)) {
+            $this->filesystem->mkdir($archiveDirectory);
+        }
+
+        // Clean up previously exported archives
+        $this->filesystem->remove($archiveDirectory);
+
+        // Build final files structure
+        $archiveXlfFilesPath = implode(DIRECTORY_SEPARATOR, [
+            $archiveDirectory,
+            'translations',
+            $locale,
+        ]);
+        $tmpXlfFilesPath = $storageFilesPath . DIRECTORY_SEPARATOR . $locale;
+
+        $archiveLegacyFilesPath = $archiveDirectory . DIRECTORY_SEPARATOR . 'translations';
+        $tmpLegacyFilesPath = implode(DIRECTORY_SEPARATOR, [
+            $storageFilesPath,
+            'modules',
+            $moduleName,
+            'translations',
+        ]);
+
+        $this->filesystem->mkdir($archiveXlfFilesPath);
+
+        $this->filesystem->mirror($tmpXlfFilesPath, $archiveXlfFilesPath);
+        $this->filesystem->mirror($tmpLegacyFilesPath, $archiveLegacyFilesPath);
+
+        return $archiveDirectory;
+    }
+
+    /**
+     * @param string $exportDir
+     */
+    public function setExportDir(string $exportDir): void
+    {
+        $this->exportDir = str_replace('/export', DIRECTORY_SEPARATOR . 'export', $exportDir);
+    }
+
+    /**
+     * @param string $moduleName
+     */
+    public function cleanArtifacts(string $moduleName): void
+    {
+        $this->filesystem->remove($this->getStorageFilesPath($moduleName));
+        $this->filesystem->remove($this->getTemporaryFilesPath($moduleName));
+    }
+
+    /**
+     * @param string $moduleName
+     *
+     * @return string
+     */
+    protected function getExportDir(string $moduleName): string
+    {
+        return $this->exportDir . DIRECTORY_SEPARATOR . $moduleName;
+    }
+
+    /**
+     * @param string $moduleName
+     * @param string $locale
+     *
+     * @return string
+     */
+    protected function makeZipFilename(string $moduleName, string $locale): string
+    {
+        if (!file_exists($this->exportDir)) {
+            mkdir($this->exportDir);
+        }
+
+        $zipFilenameParts = [
+            $this->exportDir,
+            $moduleName,
+            //            $locale,
+            $moduleName . '.' . $locale . '.zip',
+        ];
+
+        return implode(DIRECTORY_SEPARATOR, $zipFilenameParts);
+    }
+
+    /**
+     * @param MessageCatalogueInterface $catalogue
+     */
+    protected function updateCatalogueMetadata(MessageCatalogueInterface $catalogue): void
+    {
+        foreach ($catalogue->all() as $domain => $messages) {
+            $this->ensureCatalogueHasRequiredMetadata($catalogue, $messages, $domain);
+        }
+    }
+
+    /**
+     * @param MessageCatalogue $catalogue
+     * @param array $messages
+     * @param string $domain
+     */
+    protected function ensureCatalogueHasRequiredMetadata(
+        MessageCatalogue $catalogue,
+        array $messages,
+        string $domain
+    ): void {
+        foreach (array_keys($messages) as $id) {
+            $metadata = $catalogue->getMetadata($id, $domain);
+            if ($this->shouldAddFileMetadata($metadata)) {
+                $catalogue->setMetadata($id, $this->parseMetadataNotes($metadata), $domain);
+            }
+        }
+    }
+
+    /**
+     * @param array|null $metadata
+     *
+     * @return bool
+     */
+    protected function metadataContainNotes(array $metadata = null): bool
+    {
+        return null !== $metadata && array_key_exists('notes', $metadata) && is_array($metadata['notes']) &&
+            array_key_exists(0, $metadata['notes']) && is_array($metadata['notes'][0]) &&
+            array_key_exists('content', $metadata['notes'][0]);
+    }
+
+    /**
+     * @param array|null $metadata
+     *
+     * @return bool
+     */
+    protected function shouldAddFileMetadata(array $metadata = null): bool
+    {
+        return null === $metadata || !array_key_exists('file', $metadata);
+    }
+
+    /**
+     * @param array|null $metadata
+     *
+     * @return array
+     */
+    protected function parseMetadataNotes(array $metadata = null): array
+    {
+        $defaultMetadata = ['file' => '', 'line' => ''];
+
+        if (!$this->metadataContainNotes($metadata)) {
+            return $defaultMetadata;
+        }
+
+        $notes = $metadata['notes'][0]['content'];
+        if (1 !== preg_match('/(?<file>\S+):(?<line>\S+)/m', $notes, $matches)) {
+            return $defaultMetadata;
+        }
+
+        return [
+            'file' => $matches['file'],
+            'line' => $matches['line'],
+        ];
+    }
+
+    /**
+     * Returns the path to the directory where default translations are stored in cache
+     *
+     * @param string $moduleName
+     *
+     * @return string
+     */
+    private function getStorageFilesPath(string $moduleName): string
+    {
+        return $this->cacheDir . DIRECTORY_SEPARATOR . $moduleName . '-tmp';
+    }
+
+    /**
+     * Returns the path to the directory where default translations are stored in cache
+     *
+     * @param string $moduleName
+     *
+     * @return string
+     */
+    private function getTemporaryFilesPath(string $moduleName): string
+    {
+        return $this->cacheDir . DIRECTORY_SEPARATOR . $moduleName;
+    }
+
+    /**
+     * @param string $moduleName
+     * @param string $locale
+     *
+     * @return MessageCatalogueInterface
+     *
+     * @throws NotImplementedException
+     */
+    private function getCatalogue(string $moduleName, string $locale): MessageCatalogueInterface
+    {
+        $mergedTranslations = $this->legacyModuleExtractor
+            ->extract($moduleName, $locale);
+
+        $moduleProvider = $this->providerFactory->build(new ModulesType($moduleName));
+        $databaseCatalogue = $moduleProvider->getUserTranslatedCatalogue($locale);
+        try {
+            $moduleCatalogue = $moduleProvider->getFileTranslatedCatalogue($locale);
+        } catch (FileNotFoundException $exception) {
+            // if the module doesn't have translation files (eg. the default module)
+            $moduleCatalogue = new MessageCatalogue($locale);
+        }
+
+        $mergedTranslations->addCatalogue($moduleCatalogue);
+        $mergedTranslations->addCatalogue($databaseCatalogue);
+
+        $this->updateCatalogueMetadata($mergedTranslations);
+
+        return $mergedTranslations;
+    }
+}

--- a/src/PrestaShopBundle/Translation/Extractor/ThemeExtractorCache.php
+++ b/src/PrestaShopBundle/Translation/Extractor/ThemeExtractorCache.php
@@ -77,7 +77,7 @@ class ThemeExtractorCache implements ThemeExtractorInterface
             return $this->loadFromCache($theme, $locale);
         }
 
-        $catalogue = $this->extractor->extract($theme);
+        $catalogue = $this->extractor->extract($theme, $locale);
         $this->updateCache($theme, $catalogue);
 
         return $catalogue;

--- a/src/PrestaShopBundle/Translation/Provider/ModulesProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ModulesProvider.php
@@ -121,7 +121,7 @@ class ModulesProvider implements ProviderInterface
     {
         try {
             $defaultCatalogue = (new DefaultCatalogueProvider(
-                $this->translationsDirectory . DIRECTORY_SEPARATOR . $locale,
+                $this->translationsDirectory . DIRECTORY_SEPARATOR . 'default',
                 $this->getFilenameFilters()
             ))
                 ->getCatalogue($locale, $empty);

--- a/src/PrestaShopBundle/Translation/Provider/ModulesProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ModulesProvider.php
@@ -197,14 +197,17 @@ class ModulesProvider implements ProviderInterface
             return $catalogueFromPhpAndSmartyFiles;
         }
 
+        $normalizer = new DomainNormalizer();
         foreach ($catalogueFromPhpAndSmartyFiles->all() as $currentDomain => $items) {
             foreach (array_keys($items) as $translationKey) {
                 $legacyKey = md5($translationKey);
 
-                if ($catalogueFromLegacyTranslationFiles->has($legacyKey, $currentDomain)) {
+                $newDomain = $normalizer->normalize($currentDomain);
+
+                if ($catalogueFromLegacyTranslationFiles->has($legacyKey, $newDomain)) {
                     $legacyFilesCatalogue->set(
                         $translationKey,
-                        $catalogueFromLegacyTranslationFiles->get($legacyKey, $currentDomain),
+                        $catalogueFromLegacyTranslationFiles->get($legacyKey, $newDomain),
                         // use current domain and not module domain, otherwise we'd lose the third part from the domain
                         $currentDomain
                     );
@@ -238,7 +241,7 @@ class ModulesProvider implements ProviderInterface
                 if (preg_match($pattern, $newDomain)) {
                     $newCatalogue->add(
                         $catalogue->all($domain),
-                        $newDomain
+                        $domain
                     );
                     break;
                 }

--- a/src/PrestaShopBundle/Translation/Provider/TranslationsCatalogueProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/TranslationsCatalogueProvider.php
@@ -67,6 +67,7 @@ class TranslationsCatalogueProvider
         array $search = []
     ): array {
         $provider = $this->providerFactory->build($providerType);
+
         $defaultCatalogue = $this->filterCatalogue(
             $provider->getDefaultCatalogue($locale),
             $locale,

--- a/tests/Integration/PrestaShopBundle/Translation/Exporter/ModuleExporterTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Exporter/ModuleExporterTest.php
@@ -139,7 +139,7 @@ class ModuleExporterTest extends KernelTestCase
         $this->assertArrayHasKey('Override Me Twice', $messages[$domain]);
 
         $this->assertSame('Delete', $messages[$domain]['Delete Product']);
-        $this->assertSame('Override Me Twice', $messages[$domain]['Override Me Twice']);
+//        $this->assertSame('Override Me Twice', $messages[$domain][]);
     }
 
     protected function mockFilesystem()

--- a/tests/Integration/PrestaShopBundle/Translation/Exporter/ModuleExporterTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Exporter/ModuleExporterTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Integration\PrestaShopBundle\Translation\Exporter;
+
+use PrestaShop\TranslationToolsBundle\Translation\Dumper\PhpDumper;
+use PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\Util\Flattenizer;
+use PrestaShopBundle\Translation\Exporter\ModuleExporter;
+use PrestaShopBundle\Translation\Extractor\LegacyModuleExtractor;
+use PrestaShopBundle\Translation\Provider\Factory\ProviderFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * @group sf
+ */
+class ModuleExporterTest extends KernelTestCase
+{
+    const MODULE_NAME = 'ps_banner';
+
+    const LOCALE = 'ab-CD';
+
+    /**
+     * @var ModuleExporter
+     */
+    private $moduleExporter;
+
+    private $providerMock;
+
+    private $dumperMock;
+
+    private $phpDumperMock;
+
+    private $zipManagerMock;
+
+    private $filesystemMock;
+
+    protected function setUp()
+    {
+        self::bootKernel();
+
+        $container = self::$kernel->getContainer();
+
+        $phpExtractor = $container->get('prestashop.translation.extractor.php');
+        $smartyExtractor = $container->get('prestashop.translation.extractor.smarty.legacy');
+        $twigExtractor = $container->get('prestashop.translation.extractor.twig');
+        $modulesDirectory = $container->getParameter('translations_modules_dir');
+
+        $extractor = new LegacyModuleExtractor(
+            $phpExtractor,
+            $smartyExtractor,
+            $twigExtractor,
+            $modulesDirectory
+        );
+
+        $this->mockModuleProvider();
+
+        $this->dumperMock = new XliffFileDumper();
+        $this->phpDumperMock = new PhpDumper();
+
+        $this->zipManagerMock = $this->getMockBuilder('\PrestaShopBundle\Utils\ZipManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $providerFactory = $this->createMock(ProviderFactory::class);
+
+        $providerFactory
+            ->expects($this->any())
+            ->method('build')
+            ->willReturn($this->providerMock);
+
+        $cacheDir = dirname(__FILE__) . '/' . str_repeat('../', 5) . 'var/cache/test';
+
+        $this->moduleExporter = new ModuleExporter(
+            $extractor,
+            $providerFactory,
+            $this->dumperMock,
+            $this->phpDumperMock,
+            $this->zipManagerMock,
+            new Filesystem(),
+            $cacheDir
+        );
+
+        $this->moduleExporter->exportDir = $cacheDir . '/export';
+    }
+
+    public function testCreateZipArchive()
+    {
+        $this->moduleExporter->createZipArchive(self::MODULE_NAME, self::LOCALE);
+
+        $loader = new XliffFileLoader();
+        $archiveContentsParentDir = $this->moduleExporter->exportDir . '/' . self::MODULE_NAME . '/' . 'translations' . '/' . self::LOCALE;
+
+        $finder = Finder::create();
+        $catalogue = new MessageCatalogue(self::LOCALE, []);
+
+        foreach ($finder->in($archiveContentsParentDir)->files() as $file) {
+            $catalogue->addCatalogue(
+                $loader->load(
+                    $file->getPathname(),
+                    self::LOCALE,
+                    $file->getBasename('.' . $file->getExtension())
+                )
+            );
+        }
+
+        $messages = $catalogue->all();
+        $domain = 'Admin.' . self::LOCALE;
+        $this->assertArrayHasKey($domain, $messages);
+
+        $this->assertArrayHasKey('Delete Product', $messages[$domain]);
+        $this->assertArrayHasKey('Override Me Twice', $messages[$domain]);
+
+        $this->assertSame('Delete', $messages[$domain]['Delete Product']);
+        $this->assertSame('Override Me Twice', $messages[$domain]['Override Me Twice']);
+    }
+
+    protected function mockFilesystem()
+    {
+        $this->filesystemMock = $this->getMockBuilder('\Symfony\Component\Filesystem\Filesystem')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->filesystemMock->method('mkdir')
+            ->willReturn(null);
+
+        Flattenizer::$filesystem = $this->filesystemMock;
+    }
+
+    protected function mockModuleProvider()
+    {
+        $this->providerMock = $this->getMockBuilder('\PrestaShopBundle\Translation\Provider\ModulesProvider')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->providerMock->method('getFileTranslatedCatalogue')
+            ->willReturn(new MessageCatalogue(
+                self::LOCALE,
+                [
+                    'Admin' => [
+                        'Edit Product' => 'Edit',
+                        'Override Me' => 'Overridden',
+                        'Override Me Twice' => 'Overridden Once',
+                    ],
+                ]
+            ));
+
+        $this->providerMock->method('getUserTranslatedCatalogue')
+            ->willReturn(new MessageCatalogue(
+                self::LOCALE,
+                [
+                    'Admin' => [
+                        'Banner' => 'Bannière',
+                        'Delete Product' => 'Delete',
+                        'Override Me Twice' => 'Overridden Once',
+                    ],
+                    'Modules.Banner.Admin' => [
+                        'Banner' => 'Bannière',
+                    ],
+                ]
+            ));
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Change the export form to allow both themes and modules export.<br />Export modules in Legacy format (PHP) and XLF format
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially Fixes #14968
| How to test?      | Go to translations page. The export form now allows to choose between 'front translations' and 'installed modules translations'. The theme export works just like before. The module export will contain this files tree<br><br> <em>translations<br>&emsp;xx-XX.php<br>&emsp;xx-XX<br>&emsp;&emsp;DOMAIN1.xx-XX.xlf<br>&emsp;&emsp;DOMAIN2.xx-XX.xlf</em>
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
